### PR TITLE
Remove redundant git ignored file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 /node_modules/
 /vendor/bundle/
-/Brewfile.lock.json


### PR DESCRIPTION
Brew no longer generates a lockfile: https://github.com/Homebrew/homebrew-bundle/pull/1509

Per https://github.com/dxw/wordpress-template/pull/182, https://github.com/dxw/playbook/pull/1609, and https://github.com/dxw/local-env/pull/42

Closes #1